### PR TITLE
Fix #9: Update request listener URL based on Twitter API change

### DIFF
--- a/pages/background.js
+++ b/pages/background.js
@@ -28,7 +28,7 @@ if (typeof window !== "undefined") {
         requestHeaders,
       }
     },
-    { urls: ["*://*.twitter.com/*bookmark.json*"] },
+    { urls: ["*://*.twitter.com/*Bookmarks*"] },
     webRequestOptions
   )
 
@@ -37,10 +37,9 @@ if (typeof window !== "undefined") {
       tabId = details.tabId
       authorization = details.requestHeaders.find(h => h.name.toLowerCase() === "authorization").value
       csrfToken = details.requestHeaders.find(h => h.name.toLowerCase() === "x-csrf-token").value
-
       sendCredentials()
     },
-    { urls: ["*://*.twitter.com/*bookmark.json*"] },
+    { urls: ["*://*.twitter.com/*Bookmarks*"] },
     ["requestHeaders"]
   )
 


### PR DESCRIPTION
Fixes #9 which was caused I think because Twitter used to fetch bookmarks by querying for some json file and now they use this GraphQL endpoint that looks like this: `
https://twitter.com/i/api/graphql/k_gYSKrI-ExbNaKg8NF6_Q/Bookmarks?variables={"count":20,"withHighlightedLabel":false,"withTweetQuoteCount":false,"includePromotedContent":true,"withTweetResult":false,"withUserResults":false,"withNonLegacyCard":true,"withBirdwatchPivots":false}`

I could only test it in development mode because the production build command doesn't seem to work properly for me (perhaps because I'm on Windows, although I also tried on WSL). So I would test it on your end to make sure things work.